### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "ionic4-rating": "^1.0.9",
     "lodash": "^4.17.11",
     "ng-circle-progress": "^1.4.0",
-    "npm": "^6.9.0",
     "rxjs": "~6.5.1",
     "slide-ruler": "^1.1.1",
     "tslib": "^1.9.0",


### PR DESCRIPTION

Hello ZhangJinshan2233!

It seems like you have npm as one of your (dev-) dependency in improvee.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
